### PR TITLE
update java source version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.5</source>
+                    <source>1.6</source>
                     <target>1.5</target>
                 </configuration>
             </plugin>


### PR DESCRIPTION
in 1.5 methods overriding an interface definitions aren't allowed to be
annotated with @override, this is a 1.6+ Java feature.

Otherwise it will produce 35 errors.

example: 
https://github.com/jidesoft/jide-oss/blob/master/src/com/jidesoft/swing/JideSwingUtilities.java#L991#

Another fix would be to delete all this 35 appearances, but I think Java 1.6 as a compile is common these days, so it will be no probelm (and other devs here seems to use 1.6 as well)
