### PR TITLE
The api of ThemeReader has changed in JDK-17.0.10 and other newer JDKs.

### DIFF
--- a/src-jdk9/com/jidesoft/plaf/windows/XPStyle.java
+++ b/src-jdk9/com/jidesoft/plaf/windows/XPStyle.java
@@ -651,6 +651,20 @@ public class XPStyle {
                 ReflectionUtils.callStatic(SunWritableRaster.class, "markDirty", new Class[]{DataBuffer.class}, new Object[]{dbi});
 //                    SunWritableRaster.markDirty(dbi);
             }
+            catch (NoSuchMethodError err) {
+                try {
+                    ReflectionUtils.callStatic(ThemeReader.class, "paintBackground", new Class[]{ int[].class, String.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class, int.class }, new Object[]{
+                            (int[]) ReflectionUtils.callStatic(SunWritableRaster.class, "stealData", new Class[]{DataBufferInt.class, int.class}, new Object[]{dbi, 0}),
+                            /*SunWritableRaster.stealData(dbi, 0),*/
+                            part.getControlName(c), part.getValue(),
+                            State.getValue(part, state),
+                            0, 0, w, h, w, 96 /* dpi */});
+                    ReflectionUtils.callStatic(SunWritableRaster.class, "markDirty", new Class[]{DataBuffer.class}, new Object[]{dbi});
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
             catch (Exception e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
I get a `java.lang.NoSuchMethodError` when I run the code with JDK-17.0.10 that does not occur when I use JDK-17.0.9.

I think it's related to this change:
https://github.com/openjdk/jdk17u-dev/pull/1744/files#diff-48fad5afef43d7244cbd80c6534d436f698a9b54b151edaca890ec4b84f27cc0L145-R178

I'm not sure if it would be better to get the method handle once and keep it instead of catching the error every time the method is called.